### PR TITLE
Result updates

### DIFF
--- a/CSharp/Util.Test/Results/CommandResultTest.cs
+++ b/CSharp/Util.Test/Results/CommandResultTest.cs
@@ -396,6 +396,14 @@ namespace Moreland.CSharp.Util.Test.Results
             TestContext.SucessfulResult_FlatMapAppliedResultSuccess(() => TestContext.BuildCommandContext<Guid>());
 
         [Fact]
+        public void SucessfulResult_MapInvoked() => 
+            TestContext.SucessfulResult_MapInvoked(() => TestContext.BuildCommandContext<Guid>());
+
+        [Fact]
+        public void SucessfulResult_MapAppliedResultSuccess() =>
+            TestContext.SucessfulResult_MapAppliedResultSuccess(() => TestContext.BuildCommandContext<Guid>());
+
+        [Fact]
         public void SucessfulResult_OrElseNotUsed() =>
             TestContext.SucessfulResult_OrElseNotUsed(() => TestContext.BuildCommandContext<Guid>());
 
@@ -422,8 +430,20 @@ namespace Moreland.CSharp.Util.Test.Results
             TestContext.SucessfulResult_OrElseThrowOverloadDoesValueMatches(() => TestContext.BuildCommandContext<Guid>());
 
         [Fact]
+        public void FailedResult_FlatMapThrowsArgumentNullWhenMaperIsNull() =>
+            TestContext.FailedResult_FlatMapThrowsArgumentNullWhenMapperIsNull(() => TestContext.BuildCommandContext<Guid>());
+
+        [Fact]
         public void FailedResult_FlatMapNotApplied() =>
             TestContext.FailedResult_FlatMapNotApplied(() => TestContext.BuildCommandContext<Guid>());
+
+        [Fact]
+        public void FailedResult_MapThrowsArgumentNullWhenMaperIsNull() =>
+            TestContext.FailedResult_MapThrowsArgumentNullWhenMapperIsNull(() => TestContext.BuildCommandContext<Guid>());
+
+        [Fact]
+        public void FailedResult_MapNotApplied() =>
+            TestContext.FailedResult_MapNotApplied(() => TestContext.BuildCommandContext<Guid>());
 
         [Fact]
         public void FailedResult_OrElseUsed() =>
@@ -449,6 +469,10 @@ namespace Moreland.CSharp.Util.Test.Results
         public void FailedResult_OrElseThrowThrowsArgumentNullExceptionWhenSupplierIsNull() =>
             TestContext.FailedResult_OrElseThrowThrowsArgumentNullWhenSupplierIsNull(() => 
                 TestContext.BuildCommandContext<Guid>());
+
+        [Fact]
+        public void FailedResult_OrElseThrowsArgumentNullWhenSupplierIsNull() =>
+            TestContext.FailedResult_OrElseThrowThrowsArgumentNullWhenSupplierIsNull(() => TestContext.BuildCommandContext<Guid>());
 
         [Fact]
         public void ExplcitCast_ReturnsExpectedValueWhenSuccess()

--- a/CSharp/Util.Test/Results/QueryResultTest.cs
+++ b/CSharp/Util.Test/Results/QueryResultTest.cs
@@ -237,6 +237,14 @@ namespace Moreland.CSharp.Util.Test.Results
             TestContext.SucessfulResult_FlatMapAppliedResultSuccess(() => TestContext.BuildQueryContext<Guid>());
 
         [Fact]
+        public void SucessfulResult_MapInvoked() => 
+            TestContext.SucessfulResult_MapInvoked(() => TestContext.BuildQueryContext<Guid>());
+
+        [Fact]
+        public void SucessfulResult_MapAppliedResultSuccess() =>
+            TestContext.SucessfulResult_MapAppliedResultSuccess(() => TestContext.BuildQueryContext<Guid>());
+
+        [Fact]
         public void SucessfulResult_OrElseNotUsed() =>
             TestContext.SucessfulResult_OrElseNotUsed(() => TestContext.BuildQueryContext<Guid>());
 
@@ -257,8 +265,24 @@ namespace Moreland.CSharp.Util.Test.Results
             TestContext.SucessfulResult_OrElseThrowDoesValueMatches(() => TestContext.BuildQueryContext<Guid>());
 
         [Fact]
+        public void FailedResult_OrElseThrowsArgumentNullWhenSupplierIsNull() =>
+            TestContext.FailedResult_OrElseThrowThrowsArgumentNullWhenSupplierIsNull(() => TestContext.BuildQueryContext<Guid>());
+        
+        [Fact]
+        public void FailedResult_FlatMapThrowsArgumentNullWhenMapperIsNull() =>
+            TestContext.FailedResult_FlatMapThrowsArgumentNullWhenMapperIsNull(() => TestContext.BuildQueryContext<Guid>());
+
+        [Fact]
         public void FailedResult_FlatMapNotApplied() =>
             TestContext.FailedResult_FlatMapNotApplied(() => TestContext.BuildQueryContext<Guid>());
+
+        [Fact]
+        public void FailedResult_MapThrowsArgumentNullWhenMaperIsNull() =>
+            TestContext.FailedResult_MapThrowsArgumentNullWhenMapperIsNull(() => TestContext.BuildQueryContext<Guid>());
+
+        [Fact]
+        public void FailedResult_MapNotApplied() =>
+            TestContext.FailedResult_MapNotApplied(() => TestContext.BuildQueryContext<Guid>());
 
         [Fact]
         public void FailedResult_OrElseUsed() =>
@@ -292,6 +316,52 @@ namespace Moreland.CSharp.Util.Test.Results
             var (success, value, message, cause) = result;
 
             Assert.Equal(HashProxy.Combine(value, success, message, cause), result.GetHashCode());
+        }
+
+        [Fact]
+        public void Deconstruct_ValueTypeExportsProvidedValues()
+        {
+            Guid valueType = Guid.NewGuid();
+            var valueResultSuccess = QueryResult.Ok(valueType);
+            var valueResultFailure = QueryResult.Failed<Guid>(Guid.NewGuid().ToString(), new InvalidCastException());
+
+            ActAndAssertDeconstruct(valueResultSuccess);
+            ActAndAssertDeconstruct(valueResultFailure);
+
+        }
+
+        [Fact]
+        public void Deconstruct_ReferenceTypeExportsProvidedValues()
+        {
+            object @object = new object();
+            var refResultSuccess = QueryResult.Ok(@object);
+            var refResultFailure = QueryResult.Failed<object>(Guid.NewGuid().ToString(), new NotSupportedException());
+
+            ActAndAssertDeconstruct(refResultSuccess);
+            ActAndAssertDeconstruct(refResultFailure);
+        }
+
+        private static void ActAndAssertDeconstruct<T>(QueryResult<T> result)
+        {
+            if (result)
+            {
+                var (success, value, message, cause) = result;
+                Assert.Equal(result.Success, success);
+                Assert.Equal(result.Value, value);
+                Assert.Equal(result.Message, message);
+                Assert.Equal(result.Cause, cause);
+
+                (success, value, message) = result;
+                Assert.Equal(result.Success, success);
+                Assert.Equal(result.Value, value);
+                Assert.Equal(result.Message, message);
+
+                (success, value) = result;
+                Assert.Equal(result.Success, success);
+                Assert.Equal(result.Value, value);
+            }
+            else
+                Assert.Throws<InvalidOperationException>(() => (_, _, _, _) = result);
         }
     }
 }

--- a/CSharp/Util/Maybe.cs
+++ b/CSharp/Util/Maybe.cs
@@ -38,9 +38,17 @@ namespace Moreland.CSharp.Util
         public bool HasValue { get; }
 
         /// <summary>If a value is present and the value matches a given predicate, it returns a Maybe describing the value, otherwise returns an empty Maybe.</summary>
+        public Maybe<TValue> Filter(Predicate<TValue> predicate) => 
+            Where(predicate);
+
+        /// <summary>If a value is present and the value matches a given predicate, it returns a Maybe describing the value, otherwise returns an empty Maybe.</summary>
         public Maybe<TValue> Where(Predicate<TValue> predicate) => HasValue && predicate?.Invoke(Value) == true 
             ? this 
             : Maybe.Empty<TValue>();
+
+        /// <summary>If a value is present, it applies the provided Maybe-bearing mapping function to it, returns that result, otherwise returns an empty Maybe. </summary>
+        public Maybe<TMappedValue> Select<TMappedValue>(Func<TValue, TMappedValue> selector) =>
+            Map(selector);
 
         /// <summary>If a value is present, it applies the provided Maybe-bearing mapping function to it, returns that result, otherwise returns an empty Maybe. </summary>
         public Maybe<TMappedValue> Map<TMappedValue>(Func<TValue, TMappedValue> mapper)

--- a/CSharp/Util/Results/CommandResult.cs
+++ b/CSharp/Util/Results/CommandResult.cs
@@ -124,9 +124,25 @@ namespace Moreland.CSharp.Util.Results
             message = Message;
             cause = Cause;
         }
+        /// <summary>
+        /// If a value is present, apply the provided Optional-bearing mapping function to it, 
+        /// return that result, otherwise return an empty Optional.
+        /// </summary>
+        public CommandResult<TMappedValue> FlatMap<TMappedValue>(Func<TValue, CommandResult<TMappedValue>> mapper)
+        {
+            if (mapper == null)
+                throw new ArgumentNullException(nameof(mapper));
+            if (!Success)
+                return CommandResult.Failed<TMappedValue>(Message, Cause);
+            return mapper.Invoke(Value);
+        }
 
-        /// <summary>If a value is present, it applies the provided Maybe-bearing mapping function to it, returns that result, otherwise returns an empty Maybe. </summary>
-        public CommandResult<TMappedValue> FlatMap<TMappedValue>(Func<TValue, TMappedValue> mapper)
+        /// <summary>If a value is present, apply the provided mapping function to it, and if the result is non-null, return a Maybe describing the result.</summary>
+        public CommandResult<TMappedValue> Select<TMappedValue>(Func<TValue, TMappedValue> selector) => 
+            Map(selector);
+
+        /// <summary>If a value is present, apply the provided mapping function to it, and if the result is non-null, return a Maybe describing the result.</summary>
+        public CommandResult<TMappedValue> Map<TMappedValue>(Func<TValue, TMappedValue> mapper)
         {
             if (mapper == null)
                 throw new ArgumentNullException(nameof(mapper));

--- a/CSharp/Util/Results/QueryResult.cs
+++ b/CSharp/Util/Results/QueryResult.cs
@@ -76,10 +76,30 @@ namespace Moreland.CSharp.Util.Results
         }
 
         /// <summary>
-        /// If result is a success, it applies the provided Result-bearing mapping function to it, 
-        /// returns that result, otherwise returns an empty Maybe. 
+        /// If a value is present, apply the provided Optional-bearing mapping function to it, 
+        /// return that result, otherwise return an empty Optional.
         /// </summary>
-        public QueryResult<TMappedValue> FlatMap<TMappedValue>(Func<TValue, TMappedValue> mapper)
+        public QueryResult<TMappedValue> FlatMap<TMappedValue>(Func<TValue, QueryResult<TMappedValue>> mapper)
+        {
+            if (mapper == null)
+                throw new ArgumentNullException(nameof(mapper));
+            if (!Success)
+                return QueryResult.Failed<TMappedValue>(Message, Cause);
+            return mapper.Invoke(Value);
+        }
+
+        /// <summary>
+        /// If a value is present, apply the provided mapping function to it, 
+        /// and if the result is non-null, return an Optional describing the result. 
+        /// </summary>
+        public QueryResult<TMappedValue> Select<TMappedValue>(Func<TValue, TMappedValue> selector) =>
+            Map(selector);
+
+        /// <summary>
+        /// If a value is present, apply the provided mapping function to it, 
+        /// and if the result is non-null, return an Optional describing the result. 
+        /// </summary>
+        public QueryResult<TMappedValue> Map<TMappedValue>(Func<TValue, TMappedValue> mapper)
         {
             if (mapper == null)
                 throw new ArgumentNullException(nameof(mapper));

--- a/CSharp/Util/Util.csproj
+++ b/CSharp/Util/Util.csproj
@@ -10,7 +10,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageId>Moreland.CSharp.Util</PackageId>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <Authors>Terry Moreland</Authors>
     <PackageLicenseExpression></PackageLicenseExpression>
     <Company />


### PR DESCRIPTION
- corrected FlatMap to behave the same as Maybe.FlatMap (funct returns CommandResult<T> or QueryResult<T> rather than T
- added Map to provide what FLatMap previously did
- added Select, overload of Map using C# naming convention
- added Filter to Maybe which is just an overload of Where alllowing both java and C# method names
- additional unit tests