### PR TITLE
1.1.4 OrElseFlatMap

### DIFF
--- a/CSharp/Util.Test/Extensions/CollectionExtensionTests.cs
+++ b/CSharp/Util.Test/Extensions/CollectionExtensionTests.cs
@@ -1,0 +1,65 @@
+﻿//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xunit;
+
+namespace Moreland.CSharp.Util.Test.Extensions
+{
+    public class CollectionExtensionTests
+    {
+        [Fact]
+        public void AddRangeParamsAddsExpectedValues()
+        {
+            Collection<int> collection = new Collection<int>();
+
+            collection.AddRange(1, 2, 3);
+
+            Assert.Equal(new[] { 1, 2, 3 }, collection);
+        }
+
+        [Fact]
+        public void AddRangeEnumerableAddsExpectedValues()
+        {
+            Collection<int> collection = new Collection<int>();
+            var items = new List<int> { 1, 2, 3 };
+
+            collection.AddRange(items);
+
+            Assert.Equal(new[] { 1, 2, 3 }, collection);
+        }
+        [Fact]
+        public void AddRangeThrowsArgumentNullExceptionWhenCollectionNull()
+        {
+            Collection<int> collection = null!;
+            var items = new List<int> { 1, 2, 3 };
+
+            var exception = Assert.Throws<ArgumentNullException>(() => collection.AddRange(items));
+            Assert.Contains($"'{nameof(collection)}'", exception.Message);
+        }
+
+        [Fact]
+        public void AddRangeThrowsArgumentNullExceptionWhenItemsNull()
+        {
+            Collection<int> collection = new Collection<int>();
+            List<int> items = null!;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => collection.AddRange(items));
+            Assert.Contains($"'{nameof(items)}'", exception.Message);
+        }
+    }
+}

--- a/CSharp/Util.Test/Extensions/DictionaryExtensionTests.cs
+++ b/CSharp/Util.Test/Extensions/DictionaryExtensionTests.cs
@@ -51,6 +51,50 @@ namespace Moreland.CSharp.Util.Test.Extensions
         }
 
         [Fact]
+        public void Union_MergeUsingFirstChoosesFirst()
+        {
+            var first = ArrayExtensions.Of(3, 4, 5).ToDictionary(value => value, value => value.ToString());
+            var second = ArrayExtensions.Of(1, 2, 3).ToDictionary(value => value, value => value.ToString());
+
+            var result = first.UnionMergeUsingFirst(second);
+
+            Assert.Equal(first[3], result[3]);
+        }
+
+        [Fact]
+        public void Union_MergeUsingFirstContainsExpectedKeys()
+        {
+            var first = ArrayExtensions.Of(3, 4, 5).ToDictionary(value => value, value => value.ToString());
+            var second = ArrayExtensions.Of(1, 2, 3).ToDictionary(value => value, value => value.ToString());
+
+            var result = first.UnionMergeUsingFirst(second);
+
+            Assert.Equal(new[] {1, 2, 3, 4, 5}, result.Keys.OrderBy(k => k).ToArray());
+        }
+
+        [Fact]
+        public void Union_MergeUsingSecondChoosesSecond()
+        {
+            var first = ArrayExtensions.Of(3, 4, 5).ToDictionary(value => value, value => value.ToString());
+            var second = ArrayExtensions.Of(1, 2, 3).ToDictionary(value => value, value => value.ToString());
+
+            var result = first.UnionMergeUsingSecond(second);
+
+            Assert.Equal(first[3], result[3]);
+        }
+
+        [Fact]
+        public void Union_MergeUsingSecondContainsExpectedKeys()
+        {
+            var first = ArrayExtensions.Of(3, 4, 5).ToDictionary(value => value, value => value.ToString());
+            var second = ArrayExtensions.Of(1, 2, 3).ToDictionary(value => value, value => value.ToString());
+
+            var result = first.UnionMergeUsingSecond(second);
+
+            Assert.Equal(new[] {1, 2, 3, 4, 5}, result.Keys.OrderBy(k => k).ToArray());
+        }
+
+        [Fact]
         public void Intersect_ThrowsArgumentNullExceptionForNullFirstValue()
         {
             Dictionary<int, string> first = null!;
@@ -66,6 +110,26 @@ namespace Moreland.CSharp.Util.Test.Extensions
             Dictionary<int, string> second = null!;
             var exception = Assert.Throws<ArgumentNullException>(() => first.Intersect(second, UnexpectedMerge));
             Assert.Contains($"'{nameof(second)}'", exception.Message);
+        }
+
+        [Fact]
+        public void Intersect_ThrowsArgumentNullForNullMergeHandler()
+        {
+            var first = ArrayExtensions.Of(1, 2, 3).ToDictionary(value => value, value => value.ToString());
+            var second = ArrayExtensions.Of(1, 2, 3).ToDictionary(value => value, value => value.ToString());
+
+            var exception = Assert.Throws<ArgumentNullException>(() => first.Intersect(second, null!));
+            Assert.Contains("'mergeHandler'", exception.Message);
+        }
+
+        [Fact]
+        public void Intersect_ContainsExpectedKeys()
+        {
+            Dictionary<int, string> first = ArrayExtensions.Of(1, 2, 3, 4).ToDictionary(value => value, value => value.ToString());
+            Dictionary<int, string> second = ArrayExtensions.Of(3, 4, 5, 6).ToDictionary(value => value, value => value.ToString());
+
+            var result = first.Intersect(second, (a, b) => a);
+            Assert.Equal(new[] {3, 4}, result.Keys.OrderBy(k => k).ToArray());
         }
 
         private static string UnexpectedMerge(string first, string second)

--- a/CSharp/Util.Test/Extensions/EnumerableTests.cs
+++ b/CSharp/Util.Test/Extensions/EnumerableTests.cs
@@ -14,6 +14,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Moq;
 using Xunit;
 
 namespace Moreland.CSharp.Util.Test.Extensions
@@ -31,6 +32,19 @@ namespace Moreland.CSharp.Util.Test.Extensions
 
             // Assert
             Assert.Same(uids, arrayOfUids);
+        }
+
+        [Fact]
+        public void AsOrToArrayDoesCreateNewArrayWhenNotArray()
+        {
+            // Arrange
+            IEnumerable<Guid> uids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+            // Act
+            var arrayOfUids = uids.AsOrToArray();
+
+            // Assert
+            Assert.Equal(uids.ToArray(), arrayOfUids);
         }
 
         [Fact]
@@ -61,6 +75,19 @@ namespace Moreland.CSharp.Util.Test.Extensions
         }
 
         [Fact]
+        public void AsOrToListDoesCreateNewListWhenNotList()
+        {
+            // Arrange
+            IEnumerable<Guid> uids = new [] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+            // Act
+            var listOfUids = uids.AsOrToList();
+
+            // Assert
+            Assert.Equal(uids, listOfUids);
+        }
+
+        [Fact]
         public void AsOrToListReturnsEmptyArrayForNullEnumerable()
         {
             // Arrange
@@ -72,6 +99,36 @@ namespace Moreland.CSharp.Util.Test.Extensions
             // Assert
             Assert.NotNull(listOfUids);
             Assert.Empty(listOfUids);
+        }
+
+        [Fact]
+        public void ForEachThrowsArgumentNullIfItemsAreNull()
+        {
+            IEnumerable<int> items = null!;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => items.ForEach((value) => { }));
+            Assert.Contains($"'{nameof(items)}'", exception.Message);
+        }
+        [Fact]
+        public void ForEachThrowsArgumentNullIfConsumerIsNull()
+        {
+            var items = (new List<int>() { 1, 2, 3 }).AsEnumerable();
+            var exception = Assert.Throws<ArgumentNullException>(() => items.ForEach(null!));
+            Assert.Contains("'consumer'", exception.Message);
+        }
+
+        [Fact]
+        public void ForEachIteratesOverEachElement()
+        {
+            var items = (new List<int>() { 1, 2, 3 }).AsEnumerable();
+            var mock = new Mock<object>();
+            mock
+                .Setup(o => o.ToString())
+                .Returns(string.Empty);
+
+            items.ForEach(value => { _ = value + mock.Object.ToString(); });
+
+            mock.Verify(o => o.ToString(), Times.Exactly(items.Count()));
         }
     }
 }

--- a/CSharp/Util.Test/Extensions/ListExtensionTests.cs
+++ b/CSharp/Util.Test/Extensions/ListExtensionTests.cs
@@ -1,0 +1,45 @@
+﻿//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Moreland.CSharp.Util.Test.Extensions
+{
+    public class ListExtensionTests
+    {
+        [Fact]
+        public void ListOfArrayContainsProvidedItems()
+        {
+            var list = List.Of(1, 2, 3);
+            Assert.Equal(new List<int>() { 1, 2, 3 }, list);
+        }
+
+        [Fact]
+        public void ListOfEnumerableContainsProvidedItems()
+        {
+            var enumerable = (new List<int>() { 1, 2, 3 }).AsEnumerable();
+            var list = List.Of(enumerable);
+            Assert.Equal(new List<int>() { 1, 2, 3 }, list);
+        }
+
+        [Fact]
+        public void EmptyHasNoValues()
+        {
+            var empty = List.Empty<int>();
+
+            Assert.Equal(0, empty.Count);
+        }
+    }
+}

--- a/CSharp/Util.Test/Results/CommandResultTest.cs
+++ b/CSharp/Util.Test/Results/CommandResultTest.cs
@@ -203,7 +203,7 @@ namespace Moreland.CSharp.Util.Test.Results
             var uid = CommandResult.Ok(value);
 
             // Assert
-            Assert.Equal(value, uid.Value); 
+            Assert.Equal(value, uid.Value);
         }
 
         [Fact]
@@ -216,9 +216,9 @@ namespace Moreland.CSharp.Util.Test.Results
             var @string = CommandResult.Ok<string>(value);
 
             // Assert
-            Assert.Equal(value, @string.Value); 
+            Assert.Equal(value, @string.Value);
         }
-        
+
         [Fact]
         public void Ok_EmptyMessageByDefault()
         {
@@ -388,7 +388,7 @@ namespace Moreland.CSharp.Util.Test.Results
         }
 
         [Fact]
-        public void SucessfulResult_FlatMapInvoked() => 
+        public void SucessfulResult_FlatMapInvoked() =>
             TestContext.SucessfulResult_FlatMapInvoked(() => TestContext.BuildCommandContext<Guid>());
 
         [Fact]
@@ -396,7 +396,7 @@ namespace Moreland.CSharp.Util.Test.Results
             TestContext.SucessfulResult_FlatMapAppliedResultSuccess(() => TestContext.BuildCommandContext<Guid>());
 
         [Fact]
-        public void SucessfulResult_MapInvoked() => 
+        public void SucessfulResult_MapInvoked() =>
             TestContext.SucessfulResult_MapInvoked(() => TestContext.BuildCommandContext<Guid>());
 
         [Fact]
@@ -418,6 +418,21 @@ namespace Moreland.CSharp.Util.Test.Results
         [Fact]
         public void SucessfulResult_OrElseThrowDoesNotThrow() =>
             TestContext.SucessfulResult_OrElseThrowDoesNotThrow(() => TestContext.BuildCommandContext<Guid>());
+
+        [Fact]
+        public void SucessfulResult_OrElseFlatMapReturnsInitialResult()
+        {
+            // Arrange
+            var ctx = CommandResult.Ok(Guid.NewGuid());
+            Guid alternate = Guid.NewGuid();
+
+            // Act
+            var result = ctx.OrElseFlatMap((msg, ex) => CommandResult.Ok(alternate));
+
+            // Assert
+            Assert.NotEqual(alternate, result.Value);
+        }
+
         [Fact]
         public void SucessfulResult_OrElseThrowOverloadDoesNotThrow() =>
             TestContext.SucessfulResult_OrElseThrowOverloadDoesNotThrow(() => TestContext.BuildCommandContext<Guid>());
@@ -467,12 +482,26 @@ namespace Moreland.CSharp.Util.Test.Results
 
         [Fact]
         public void FailedResult_OrElseThrowThrowsArgumentNullExceptionWhenSupplierIsNull() =>
-            TestContext.FailedResult_OrElseThrowThrowsArgumentNullWhenSupplierIsNull(() => 
+            TestContext.FailedResult_OrElseThrowThrowsArgumentNullWhenSupplierIsNull(() =>
                 TestContext.BuildCommandContext<Guid>());
 
         [Fact]
         public void FailedResult_OrElseThrowsArgumentNullWhenSupplierIsNull() =>
             TestContext.FailedResult_OrElseThrowThrowsArgumentNullWhenSupplierIsNull(() => TestContext.BuildCommandContext<Guid>());
+
+        [Fact]
+        public void FailedResult_OrElseFlatMapReturnsMappedValue() 
+        {
+            // Arrange
+            var ctx = CommandResult.Failed<Guid>("error", new NotImplementedException("not implemented"));
+            Guid alternate = Guid.NewGuid();
+
+            // Act
+            var result = ctx.OrElseFlatMap((msg, ex) => CommandResult.Ok(alternate));
+
+            // Assert
+            Assert.Equal(alternate, result.Value);
+        }
 
         [Fact]
         public void ExplcitCast_ReturnsExpectedValueWhenSuccess()

--- a/CSharp/Util.Test/Results/QueryResultTest.cs
+++ b/CSharp/Util.Test/Results/QueryResultTest.cs
@@ -261,8 +261,22 @@ namespace Moreland.CSharp.Util.Test.Results
             TestContext.SucessfulResult_OrElseThrowDoesNotThrow(() => TestContext.BuildQueryContext<Guid>());
 
         [Fact]
-        public void SucessfulResult_OrElseThrowDoesValueMatches() =>
+        public void SucessfulResult_OrElseThrowValueMatches() =>
             TestContext.SucessfulResult_OrElseThrowDoesValueMatches(() => TestContext.BuildQueryContext<Guid>());
+
+        [Fact]
+        public void SucessfulResult_OrElseFlatMapReturnsInitialResult()
+        {
+            // Arrange
+            var ctx = QueryResult.Ok(Guid.NewGuid());
+            Guid alternate = Guid.NewGuid();
+
+            // Act
+            var result = ctx.OrElseFlatMap((msg, ex) => QueryResult.Ok(alternate));
+
+            // Assert
+            Assert.NotEqual(alternate, result.Value);
+        }
 
         [Fact]
         public void FailedResult_OrElseThrowsArgumentNullWhenSupplierIsNull() =>
@@ -271,6 +285,20 @@ namespace Moreland.CSharp.Util.Test.Results
         [Fact]
         public void FailedResult_FlatMapThrowsArgumentNullWhenMapperIsNull() =>
             TestContext.FailedResult_FlatMapThrowsArgumentNullWhenMapperIsNull(() => TestContext.BuildQueryContext<Guid>());
+
+        [Fact]
+        public void FailedResult_OrElseFlatMapReturnsMappedValue() 
+        {
+            // Arrange
+            var ctx = QueryResult.Failed<Guid>("error", new NotImplementedException("not implemented"));
+            Guid alternate = Guid.NewGuid();
+
+            // Act
+            var result = ctx.OrElseFlatMap((msg, ex) => QueryResult.Ok(alternate));
+
+            // Assert
+            Assert.Equal(alternate, result.Value);
+        }
 
         [Fact]
         public void FailedResult_FlatMapNotApplied() =>

--- a/CSharp/Util/Extensions/EnumerableExtensions.cs
+++ b/CSharp/Util/Extensions/EnumerableExtensions.cs
@@ -43,7 +43,7 @@ namespace System.Linq
         /// Performs the specified action on each item of the <see cref="IEnumerable{T}"/>
         /// </summary>
         /// <exception cref="ArgumentNullException">if either <paramref name="consumer"/> or <paramref name="items"/> are <c>null</c></exception>
-        public static void Foreach<T>(this IEnumerable<T> items, Action<T> consumer)
+        public static void ForEach<T>(this IEnumerable<T> items, Action<T> consumer)
         {
             if (items == null)
                 throw new ArgumentNullException(nameof(items));

--- a/CSharp/Util/Results/CommandResult.cs
+++ b/CSharp/Util/Results/CommandResult.cs
@@ -190,25 +190,25 @@ namespace Moreland.CSharp.Util.Results
         }
 
         /// <summary>
-        /// Returns the current result if successful or uses <paramref name="handleError"/> to handle the error
+        /// Returns the current result if successful or uses <paramref name="mapper"/> to handle the error
         /// allow the result to be converted to an alternate successful result
         /// </summary>
-        /// <param name="handleError">
+        /// <param name="mapper">
         /// <see cref="Func{string, Exception?, CommandResult{TValue}}"/> given message and 
-        /// exception cause and returns a <see cref="CommandResult{TValue}"/> as an alternate result
+        /// exception cause and returns a <see cref="CommandResult{TValue}"/> to an alternate result
         /// </param>
         /// <returns>
         /// current result if successful or uses <paramref name="handleError"/> to handle the error
         /// allow the result to be converted to an alternate successful result
         /// </returns>
-        public CommandResult<TValue> OrElseHandleError(Func<string, Exception?, CommandResult<TValue>> handleError)
+        public CommandResult<TValue> OrElseFlatMap(Func<string, Exception?, CommandResult<TValue>> mapper)
         {
-            if (handleError == null)
-                throw new ArgumentNullException(nameof(handleError));
+            if (mapper == null)
+                throw new ArgumentNullException(nameof(mapper));
 
             return Success
                 ? this
-                : handleError.Invoke(Message, Cause);
+                : mapper.Invoke(Message, Cause);
         }
 
         private ValueResultCore<TValue> ValueResult { get; }

--- a/CSharp/Util/Results/CommandResult.cs
+++ b/CSharp/Util/Results/CommandResult.cs
@@ -189,6 +189,28 @@ namespace Moreland.CSharp.Util.Results
             throw exceptionSupplier.Invoke(Message, Cause);
         }
 
+        /// <summary>
+        /// Returns the current result if successful or uses <paramref name="handleError"/> to handle the error
+        /// allow the result to be converted to an alternate successful result
+        /// </summary>
+        /// <param name="handleError">
+        /// <see cref="Func{string, Exception?, CommandResult{TValue}}"/> given message and 
+        /// exception cause and returns a <see cref="CommandResult{TValue}"/> as an alternate result
+        /// </param>
+        /// <returns>
+        /// current result if successful or uses <paramref name="handleError"/> to handle the error
+        /// allow the result to be converted to an alternate successful result
+        /// </returns>
+        public CommandResult<TValue> OrElseHandleError(Func<string, Exception?, CommandResult<TValue>> handleError)
+        {
+            if (handleError == null)
+                throw new ArgumentNullException(nameof(handleError));
+
+            return Success
+                ? this
+                : handleError.Invoke(Message, Cause);
+        }
+
         private ValueResultCore<TValue> ValueResult { get; }
 
         #region IEquatable{QueryResult{TValue}}

--- a/CSharp/Util/Results/QueryResult.cs
+++ b/CSharp/Util/Results/QueryResult.cs
@@ -146,25 +146,25 @@ namespace Moreland.CSharp.Util.Results
         }
 
         /// <summary>
-        /// Returns the current result if successful or uses <paramref name="handleError"/> to handle the error
+        /// Returns the current result if successful or uses <paramref name="mapper"/> to handle the error
         /// allow the result to be converted to an alternate successful result
         /// </summary>
-        /// <param name="handleError">
+        /// <param name="mapper">
         /// <see cref="Func{string, Exception?, QueryResult{TValue}}"/> given message and 
-        /// exception cause and returns a <see cref="QueryResult{TValue}"/> as an alternate result
+        /// exception cause and returns a <see cref="QueryResult{TValue}"/> to an alternate result
         /// </param>
         /// <returns>
         /// current result if successful or uses <paramref name="handleError"/> to handle the error
         /// allow the result to be converted to an alternate successful result
         /// </returns>
-        public QueryResult<TValue> OrElseHandleError(Func<string, Exception?, QueryResult<TValue>> handleError)
+        public QueryResult<TValue> OrElseFlatMap(Func<string, Exception?, QueryResult<TValue>> mapper)
         {
-            if (handleError == null)
-                throw new ArgumentNullException(nameof(handleError));
+            if (mapper == null)
+                throw new ArgumentNullException(nameof(mapper));
 
             return Success
                 ? this
-                : handleError.Invoke(Message, Cause);
+                : mapper.Invoke(Message, Cause);
         }
 
         private ValueResultCore<TValue> ValueResult { get; }

--- a/CSharp/Util/Results/QueryResult.cs
+++ b/CSharp/Util/Results/QueryResult.cs
@@ -145,6 +145,28 @@ namespace Moreland.CSharp.Util.Results
             throw exceptionSupplier.Invoke(Message, Cause);
         }
 
+        /// <summary>
+        /// Returns the current result if successful or uses <paramref name="handleError"/> to handle the error
+        /// allow the result to be converted to an alternate successful result
+        /// </summary>
+        /// <param name="handleError">
+        /// <see cref="Func{string, Exception?, QueryResult{TValue}}"/> given message and 
+        /// exception cause and returns a <see cref="QueryResult{TValue}"/> as an alternate result
+        /// </param>
+        /// <returns>
+        /// current result if successful or uses <paramref name="handleError"/> to handle the error
+        /// allow the result to be converted to an alternate successful result
+        /// </returns>
+        public QueryResult<TValue> OrElseHandleError(Func<string, Exception?, QueryResult<TValue>> handleError)
+        {
+            if (handleError == null)
+                throw new ArgumentNullException(nameof(handleError));
+
+            return Success
+                ? this
+                : handleError.Invoke(Message, Cause);
+        }
+
         private ValueResultCore<TValue> ValueResult { get; }
 
         #region IEquatable{QueryResult{TValue}}

--- a/CSharp/Util/Util.csproj
+++ b/CSharp/Util/Util.csproj
@@ -10,7 +10,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageId>Moreland.CSharp.Util</PackageId>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
     <Authors>Terry Moreland</Authors>
     <PackageLicenseExpression></PackageLicenseExpression>
     <Company />


### PR DESCRIPTION
## Description

- added new function to QueryResult<T> and CommandResult<T>: OrElseFlatMap allowing conversion of error result to an alternate result value with the intent to handle known errors converting them to a success.

### Use Case
- QueryResult<bool> where the bool represents success or failure of the operation.  The results success/failure represents whether the query succeeded but not the result of the query itself, however failure of the query may be a known failure which can be used to represent a successful query with result of false

## Testing

- introduction of further unit tests to cover new and existing functionality