### PR TITLE
Additional unit test coverage

### DIFF
--- a/CSharp/Util.Test.Old/HashCodeBuilderTest.cs
+++ b/CSharp/Util.Test.Old/HashCodeBuilderTest.cs
@@ -20,22 +20,6 @@ namespace Moreland.CSharp.Util.Test.Old
     public class HashCodeBuilderTest
     {
         [Fact]
-        public void Create_HashCodeZeroWhenEmpty()
-        {
-            var builder = HashCodeBuilder.Create();
-            int hasCode = builder.ToHashCode();
-            Assert.Equal(0, hasCode);
-        }
-
-        [Fact]
-        public void Create_NullValuesGiveHashCodeOfZero()
-        {
-            var builder = HashCodeBuilder.Create(null, null, null);
-            var hashCode = builder.ToHashCode();
-            Assert.Equal(0, hashCode);
-        }
-
-        [Fact]
         public void Equals_EqualWhenBuiltFromSameValues()
         {
             var first = HashCodeBuilder.Create(1, 2, 3);

--- a/CSharp/Util.Test/HashCodeBuilderTests.cs
+++ b/CSharp/Util.Test/HashCodeBuilderTests.cs
@@ -91,20 +91,47 @@ namespace Moreland.CSharp.Util.Test
         [TestCase(10, 20, ExpectedResult = -1)]
         [TestCase(10, 10, ExpectedResult = 0)]
         [TestCase(20, 10, ExpectedResult = 1)]
-        public int CompareTo_ReturnsExpectedResult_WhenComparingProvidedValues(int firstvalue, int secondValue)
+        [TestCase(20, null, ExpectedResult = 1)]
+        public int CompareTo_ReturnsExpectedResult_WhenComparingProvidedValues(int firstValue, int? secondValue)
         {
-            var first = HashCodeBuilder.Create(firstvalue);
-            var second = HashCodeBuilder.Create(secondValue);
+            var first = HashCodeBuilder.Create(firstValue);
+            var second = secondValue != null ? HashCodeBuilder.Create(secondValue) : null;
             return first.CompareTo(second);
         }
 
         [TestCase(10, 20, ExpectedResult = false)]
         [TestCase(10, 10, ExpectedResult = true)]
         [TestCase(20, 10, ExpectedResult = false)]
-        public bool OperatorEquals_ReturnsExpectedResult_WhenComparingProvidedValue(int firstvalue, int secondValue)
+        [TestCase(20, null, ExpectedResult = false)]
+        public bool ObjectEquals_ReturnsExpectedResult_WhenUsingProvidedValues(int firstValue, int? secondValue)
         {
-            var first = HashCodeBuilder.Create(firstvalue);
-            var second = HashCodeBuilder.Create(secondValue);
+            var first = HashCodeBuilder.Create(firstValue);
+            object? second = secondValue != null ? HashCodeBuilder.Create(secondValue) : null;
+
+            return first.Equals(second);
+        }
+
+        [TestCase(10, 20, ExpectedResult = false)]
+        [TestCase(10, 10, ExpectedResult = true)]
+        [TestCase(20, 10, ExpectedResult = false)]
+        [TestCase(20, null, ExpectedResult = false)]
+        public bool IEquatableEquals_ReturnsExpectedResult_WhenUsingProvidedValues(int firstValue, int? secondValue)
+        {
+            var first = HashCodeBuilder.Create(firstValue);
+            var second = secondValue != null ? HashCodeBuilder.Create(secondValue) : null;
+
+            return first.Equals(second);
+        }
+
+        [TestCase(10, 20, ExpectedResult = false)]
+        [TestCase(10, 10, ExpectedResult = true)]
+        [TestCase(20, 10, ExpectedResult = false)]
+        [TestCase(null, 10, ExpectedResult = false)]
+        [TestCase(20, null, ExpectedResult = false)]
+        public bool OperatorEquals_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
+        {
+            var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
+            var second = secondValue != null ? HashCodeBuilder.Create(secondValue) : null;
 
             return first == second;
         }
@@ -112,25 +139,67 @@ namespace Moreland.CSharp.Util.Test
         [TestCase(10, 20, ExpectedResult = true)]
         [TestCase(10, 10, ExpectedResult = false)]
         [TestCase(20, 10, ExpectedResult = true)]
-        public bool OperatorNotEqual_ReturnsExpectedResult_WhenComparingProvidedValue(int firstvalue, int secondValue)
+        public bool OperatorNotEqual_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
         {
-            var first = HashCodeBuilder.Create(firstvalue);
-            var second = HashCodeBuilder.Create(secondValue);
+            var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
+            var second = secondValue != null ? HashCodeBuilder.Create(secondValue) : null;
 
             return first != second;
         }
 
-        /*
-
-        [TestCase(10, 20, ExpectedResult = )]
-        [TestCase(10, 10, ExpectedResult = )]
-        [TestCase(20, 10, ExpectedResult = )]
-        public bool Operator_ReturnsExpectedResult_WhenComparingProvidedValue(int firstvalue, int secondValue)
+        [TestCase(10, 20, ExpectedResult = false)]
+        [TestCase(10, 10, ExpectedResult = false)]
+        [TestCase(20, 10, ExpectedResult = true)]
+        public bool OperatorGreaterThan_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
         {
-            var first = HashCodeBuilder.Create(firstvalue);
-            var second = HashCodeBuilder.Create(secondValue);
+            var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
+            var second = secondValue != null ? HashCodeBuilder.Create(secondValue) : null;
 
+            return first! > second!;
         }
-        */
+
+        [TestCase(10, 20, ExpectedResult = false)]
+        [TestCase(10, 10, ExpectedResult = true)]
+        [TestCase(20, 10, ExpectedResult = true)]
+        public bool OperatorGreaterThanOrEqualTo_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
+        {
+            var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
+            var second = secondValue != null ? HashCodeBuilder.Create(secondValue) : null;
+
+            return first! >= second!;
+        }
+
+        [TestCase(10, 20, ExpectedResult = true)]
+        [TestCase(10, 10, ExpectedResult = false)]
+        [TestCase(20, 10, ExpectedResult = false)]
+        public bool OperatorLessThan_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
+        {
+            var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
+            var second = secondValue != null ? HashCodeBuilder.Create(secondValue) : null;
+
+            return first! < second!;
+        }
+
+        [TestCase(10, 20, ExpectedResult = true)]
+        [TestCase(10, 10, ExpectedResult = true)]
+        [TestCase(20, 10, ExpectedResult = false)]
+        public bool OperatorLessThanOrEqualTo_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
+        {
+            var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
+            var second = secondValue != null ? HashCodeBuilder.Create(secondValue) : null;
+
+            return first! <= second!;
+        }
+
+        [Test]
+        public void GetHashCode_ReturnsToHashCode_Always()
+        {
+            var builder = HashCodeBuilder.Create(_values);
+
+            int toHashCode = builder.ToHashCode();
+            int getHashCode = builder.GetHashCode();
+
+            Assert.That(getHashCode, Is.EqualTo(toHashCode));
+        }
     }
 }

--- a/CSharp/Util.Test/HashCodeBuilderTests.cs
+++ b/CSharp/Util.Test/HashCodeBuilderTests.cs
@@ -1,0 +1,136 @@
+﻿//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using static Moreland.CSharp.Util.Test.TestData.RandomValueFactory;
+
+namespace Moreland.CSharp.Util.Test
+{
+    [TestFixture]
+    public sealed class HashCodeBuilderTests
+    {
+        private object?[] _values = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            var values = new List<object?> 
+            { 
+                BuildRandomInt32(),
+                BuildRandomBoolean(),
+                BuildRandomDecimal(),
+                null,
+                BuildRandomString(),
+                BuildRandomListOfString(),
+                BuildRandomGuid()
+            };
+            _values = values.ToArray();
+        }
+
+        [Test]
+        public void ToHashCode_ReturnsZero_WhenEmpty()
+        {
+            var builder = HashCodeBuilder.Create();
+
+            var hashCode = builder.ToHashCode();
+
+            Assert.That(hashCode, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ToHashCode_ReturnsNonZero_WhenNotEmpty()
+        {
+            var builder = HashCodeBuilder.Create(_values);
+
+            var hashCode = builder.ToHashCode();
+
+            Assert.That(hashCode, Is.Not.EqualTo(0));
+        }
+
+        [Test]
+        public void ToHashCode_ReturnsZero_WhenAllValuesAreNull()
+        {
+            var builder = HashCodeBuilder.Create(null, null, null, null, null);
+
+            var hashCode = builder.ToHashCode();
+
+            Assert.That(hashCode, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Equals_ReturnsTrue_WhenBuiltSameValuesUsingCreate()
+        {
+            var first = HashCodeBuilder.Create(1, 2, 3);
+            var second = HashCodeBuilder.Create(1, 2, 3);
+
+            Assert.That(first, Is.EqualTo(second));
+        }
+
+        [Test]
+        public void Equals_ReturnsTrue_WhenBuiltSameValuesUsingCreateOrAdd()
+        {
+            var first = HashCodeBuilder.Create(1, 2, 3);
+            first = first.WithAddedValues(4, 5, 6);
+            var second = HashCodeBuilder.Create(1, 2, 3, 4, 5, 6);
+
+            Assert.That(first, Is.EqualTo(second));
+        }
+
+        [TestCase(10, 20, ExpectedResult = -1)]
+        [TestCase(10, 10, ExpectedResult = 0)]
+        [TestCase(20, 10, ExpectedResult = 1)]
+        public int CompareTo_ReturnsExpectedResult_WhenComparingProvidedValues(int firstvalue, int secondValue)
+        {
+            var first = HashCodeBuilder.Create(firstvalue);
+            var second = HashCodeBuilder.Create(secondValue);
+            return first.CompareTo(second);
+        }
+
+        [TestCase(10, 20, ExpectedResult = false)]
+        [TestCase(10, 10, ExpectedResult = true)]
+        [TestCase(20, 10, ExpectedResult = false)]
+        public bool OperatorEquals_ReturnsExpectedResult_WhenComparingProvidedValue(int firstvalue, int secondValue)
+        {
+            var first = HashCodeBuilder.Create(firstvalue);
+            var second = HashCodeBuilder.Create(secondValue);
+
+            return first == second;
+        }
+
+        [TestCase(10, 20, ExpectedResult = true)]
+        [TestCase(10, 10, ExpectedResult = false)]
+        [TestCase(20, 10, ExpectedResult = true)]
+        public bool OperatorNotEqual_ReturnsExpectedResult_WhenComparingProvidedValue(int firstvalue, int secondValue)
+        {
+            var first = HashCodeBuilder.Create(firstvalue);
+            var second = HashCodeBuilder.Create(secondValue);
+
+            return first != second;
+        }
+
+        /*
+
+        [TestCase(10, 20, ExpectedResult = )]
+        [TestCase(10, 10, ExpectedResult = )]
+        [TestCase(20, 10, ExpectedResult = )]
+        public bool Operator_ReturnsExpectedResult_WhenComparingProvidedValue(int firstvalue, int secondValue)
+        {
+            var first = HashCodeBuilder.Create(firstvalue);
+            var second = HashCodeBuilder.Create(secondValue);
+
+        }
+        */
+    }
+}

--- a/CSharp/Util.Test/HashCodeBuilderTests.cs
+++ b/CSharp/Util.Test/HashCodeBuilderTests.cs
@@ -139,6 +139,8 @@ namespace Moreland.CSharp.Util.Test
         [TestCase(10, 20, ExpectedResult = true)]
         [TestCase(10, 10, ExpectedResult = false)]
         [TestCase(20, 10, ExpectedResult = true)]
+        [TestCase(null, 10, ExpectedResult = true)]
+        [TestCase(20, null, ExpectedResult = true)]
         public bool OperatorNotEqual_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
         {
             var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
@@ -150,6 +152,8 @@ namespace Moreland.CSharp.Util.Test
         [TestCase(10, 20, ExpectedResult = false)]
         [TestCase(10, 10, ExpectedResult = false)]
         [TestCase(20, 10, ExpectedResult = true)]
+        [TestCase(null, 10, ExpectedResult = false)]
+        [TestCase(20, null, ExpectedResult = true)]
         public bool OperatorGreaterThan_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
         {
             var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
@@ -161,6 +165,8 @@ namespace Moreland.CSharp.Util.Test
         [TestCase(10, 20, ExpectedResult = false)]
         [TestCase(10, 10, ExpectedResult = true)]
         [TestCase(20, 10, ExpectedResult = true)]
+        [TestCase(null, 10, ExpectedResult = false)]
+        [TestCase(20, null, ExpectedResult = true)]
         public bool OperatorGreaterThanOrEqualTo_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
         {
             var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
@@ -172,6 +178,8 @@ namespace Moreland.CSharp.Util.Test
         [TestCase(10, 20, ExpectedResult = true)]
         [TestCase(10, 10, ExpectedResult = false)]
         [TestCase(20, 10, ExpectedResult = false)]
+        [TestCase(null, 10, ExpectedResult = true)]
+        [TestCase(20, null, ExpectedResult = false)]
         public bool OperatorLessThan_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
         {
             var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;
@@ -183,6 +191,8 @@ namespace Moreland.CSharp.Util.Test
         [TestCase(10, 20, ExpectedResult = true)]
         [TestCase(10, 10, ExpectedResult = true)]
         [TestCase(20, 10, ExpectedResult = false)]
+        [TestCase(null, 10, ExpectedResult = true)]
+        [TestCase(20, null, ExpectedResult = false)]
         public bool OperatorLessThanOrEqualTo_ReturnsExpectedResult_WhenComparingProvidedValue(int? firstValue, int? secondValue)
         {
             var first = firstValue != null ? HashCodeBuilder.Create(firstValue) : null;

--- a/CSharp/Util/HashCodeBuilder.cs
+++ b/CSharp/Util/HashCodeBuilder.cs
@@ -12,6 +12,7 @@
 // 
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
@@ -90,7 +91,7 @@ namespace Moreland.CSharp.Util
         {
             _piecewiseCode = piecewiseHashCodeBuilder;
         }
-        private static int CalculateHashCode(in int initialValue, object?[] objects) =>
+        private static int CalculateHashCode(in int initialValue, IEnumerable<object?> objects) =>
             objects.Aggregate(initialValue, (current, @object) => (current * 397) ^ (@object?.GetHashCode() ?? 0));
         #endregion
 

--- a/CSharp/Util/HashCodeBuilder.cs
+++ b/CSharp/Util/HashCodeBuilder.cs
@@ -119,10 +119,11 @@ namespace Moreland.CSharp.Util
         /// <inheritdoc cref="object.Equals(object?)"/>
         /// </summary>
         public override bool Equals(object? obj) => Equals(obj as HashCodeBuilder);
+
         /// <summary>
         /// <inheritdoc cref="object.GetHashCode"/>
         /// </summary>
-        public override int GetHashCode() => _piecewiseCode.GetHashCode();
+        public override int GetHashCode() => ToHashCode();
 
         #endregion
     }


### PR DESCRIPTION
## Changes
- added initial ```HashCodeBuilderTests``` to  Util.Test
- removed some redundant tests from old unit test project
- changed private method in ```HashCodeBuilder``` to take ```IEnumerable``` instead of array